### PR TITLE
Added new functionality to allow users to send content to be diffed as p...

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This [blog post](http://arnab-deka.com/posts/2013/02/hello-jquery-prettytextdiff
 explains things in a bit more detail.
 
 ## Demo
-[jsfiddle demo](http://jsfiddle.net/YwSVY/)
+[jsfiddle demo](http://jsfiddle.net/q7hyfev8/5/)
 
 ## Download
 From the [jQuery plugins site](http://plugins.jquery.com/pretty-text-diff/).
@@ -92,6 +92,18 @@ in the [jsfiddle demo](#demo).
     <td>debug</td>
     <td>false</td>
     <td>see some debug output in your browser's console</td>
+  </tr>
+
+  <tr>
+    <td>originalContent</td>
+    <td>None</td>
+    <td>Pass the original content as a parameter in your JS file, instead of creating an element in your HTML code to extract this content.</td>
+  </tr>
+
+  <tr>
+    <td>changedContent</td>
+    <td>None</td>
+    <td>Pass the changed content as a parameter in your JS file, instead of creating an element in your HTML code to extract this content.</td>
   </tr>
 </table>
 

--- a/jquery.pretty-text-diff.coffee
+++ b/jquery.pretty-text-diff.coffee
@@ -1,5 +1,5 @@
 ###
-@preserve jQuery.PrettyTextDiff 1.0.3
+@preserve jQuery.PrettyTextDiff 1.0.4
 See https://github.com/arnab/jQuery.PrettyTextDiff/
 ###
 
@@ -19,9 +19,14 @@ $.fn.extend
 
       dmp = new diff_match_patch();
       @each ->
-        original = $(settings.originalContainer, this).text()
+        if settings.originalContent and settings.changedContent
+          original = $('<div />').html(settings.originalContent).text()
+          changed = $('<div />').html(settings.changedContent).text()
+        else
+          original = $(settings.originalContainer, this).text()
+          changed = $(settings.changedContainer, this).text()
+
         $.fn.prettyTextDiff.debug "Original text found: ", original, settings
-        changed = $(settings.changedContainer, this).text()
         $.fn.prettyTextDiff.debug "Changed  text found: ", changed, settings
 
         diffs = dmp.diff_main(original, changed)


### PR DESCRIPTION
...arameters to the 'prettyTextDiff' function.

Currently, the user has to set th text of the HTML elements i.e. the originalContainer and the changedContainer. This required the HTML content of the two containers to be part of the page source which caused web pages to be prone to XSS attacks. This method allows the user to set the HTML content to a JS variable and pass it as a parameter to this function. Both functionalities are supported to not break the existing plugin.
